### PR TITLE
[do not merge] board approved policy documents

### DIFF
--- a/policies/RSS-contribution-and-IP-policy.md
+++ b/policies/RSS-contribution-and-IP-policy.md
@@ -1,0 +1,265 @@
+## **CONTRIBUTION AND INTELLECTUAL PROPERTY POLICY**
+
+### **Reciprocal Space Station Consortium**
+
+**Adopted by:** Board of the Reciprocal Space Station Consortium  
+ **Effective Date:** \[Date\]  
+ **Administered by:** Open Molecular Software Foundation, as Operating Legal Entity for RSS
+
+This Contribution and Intellectual Property Policy (the “**Policy**”) governs contributions to the Reciprocal Space Station Consortium (“**RSS**” or the “**Consortium**”) and the treatment of intellectual property relating to Consortium-Funded Work and other RSS project materials.
+
+This Policy is adopted pursuant to the Charter of RSS (the “**Charter**”). In the event of conflict, the Charter controls over this Policy, and applicable law, OMSF governing documents, and binding external obligations control over both.
+
+## **1\. Purpose**
+
+RSS is an open-source software consortium for structural biology. This Policy is intended to:
+
+* support open-source development under permissive terms;  
+* clarify the treatment of contributions made to RSS projects;  
+* distinguish Consortium-Funded Work from External Work;  
+* avoid overclaiming rights that contributors may not have authority to grant;  
+* preserve the rights and obligations of contributors’ home institutions and funders where applicable;  
+* provide a workable framework for software, documentation, data, and related materials;  
+* protect the Consortium’s ability to maintain, distribute, and steward RSS projects over time.
+
+## **2\. Scope**
+
+This Policy applies to:
+
+* software repositories and related materials maintained as RSS projects;  
+* Consortium-Funded Work;  
+* contributions submitted for inclusion in RSS-managed projects;  
+* documentation, benchmarks, training materials, and other project materials produced for RSS.
+
+This Policy does not, by itself, override:
+
+* employment agreements;  
+* contractor agreements;  
+* institutional intellectual property policies;  
+* grant or subaward terms;  
+* separately executed contribution agreements;  
+* any other binding external obligations.
+
+## **3\. Governing Principles**
+
+### **3.1 Open-Source Mission**
+
+RSS software is intended to be publicly released under permissive open-source terms consistent with the Charter.
+
+### **3.2 Respect for Institutional Constraints**
+
+Many contributors participate through universities, laboratories, research institutes, or companies. RSS recognizes that contributors may be subject to institutional policies or contractual obligations governing ownership, assignment, disclosure, or licensing of their work.
+
+### **3.3 No Overclaiming**
+
+No person shall be deemed to transfer or assign rights to RSS merely by participating in governance, discussion, or membership activities. Rights transfer only through applicable law, contract, explicit contribution terms, or other legally effective mechanisms.
+
+### **3.4 Practical Stewardship**
+
+RSS must be able to maintain and distribute its software and related materials. Contribution practices should therefore provide sufficient rights for RSS and its users to use, modify, distribute, and maintain accepted contributions.
+
+### **3.5 Distinction Between Contribution and Governance**
+
+A person may be a Developer, Member representative, Board member, or other participant in RSS without thereby becoming a contributor to a particular repository or assigning any intellectual property rights beyond those expressly granted.
+
+## **4\. Definitions**
+
+For purposes of this Policy:
+
+**A. Consortium-Funded Work** has the meaning given in the Charter.
+
+**B. Consortium-Funded Project** has the meaning given in the Charter.
+
+**C. External Work** has the meaning given in the Charter.
+
+**D. Contribution** means any code, documentation, patch, dataset, benchmark, tutorial, technical note, or other material intentionally submitted for inclusion in an RSS-managed project or repository.
+
+**E. Contributor** means a person or entity making a Contribution.
+
+**F. Maintainer** means a person authorized under RSS project practice to review, accept, reject, or manage Contributions to a given project or repository.
+
+**G. Project Materials** means software, documentation, datasets, benchmarks, websites, training materials, and related materials maintained as part of RSS.
+
+## **5\. Categories of Work**
+
+### **5.1 Consortium-Funded Work**
+
+Consortium-Funded Work is work materially supported through funding, personnel, or resources administered by RSS or the Operating Legal Entity. Its treatment is governed by the Charter, this Policy, the Release and Publication Policy, and any applicable employment, contractor, grant, or project-specific agreements.
+
+### **5.2 External Work**
+
+External Work is work contributed independently outside such support. External Work does not become Consortium-Funded Work merely because its author is a Developer, Board member, Member representative, or participant in RSS.
+
+### **5.3 Accepted Contributions**
+
+A Contribution accepted into an RSS-managed project becomes part of the relevant Project Materials and is thereafter governed by the license, governance, and maintenance practices applicable to that project, subject to any separately executed agreement.
+
+## **6\. Licensing of RSS Software and Materials**
+
+### **6.1 Software License**
+
+Software maintained as part of RSS shall be released under a permissive open-source license approved by the Open Source Initiative and materially consistent with the Charter.
+
+Unless otherwise approved by the Board for a specific project, RSS software should use a license no more restrictive than Apache 2.0.
+
+### **6.2 Non-Software Materials**
+
+Documentation, tutorials, benchmarks, training materials, and related non-software materials may be released under an appropriate permissive public license selected by RSS leadership or the Board for the relevant project.
+
+### **6.3 Notice of Applicable License**
+
+Each RSS-managed repository or project should clearly identify its applicable license or licenses.
+
+## **7\. Contribution Basis**
+
+### **7.1 Standard Rule for Accepted Contributions**
+
+As a condition of submitting a Contribution for inclusion in an RSS-managed project, each Contributor must make the Contribution under one of the following bases, as determined by RSS project practice and any Board-approved standards:
+
+* a Developer Certificate of Origin or comparable signed-off contribution process;  
+* a contributor license agreement;  
+* a contribution assignment agreement;  
+* an employer- or institution-approved contribution process;  
+* another documented mechanism approved by OMSF or the Board.
+
+RSS may use different contribution mechanisms for different projects where appropriate, provided the mechanism is documented and legally sufficient for stewardship of the project.
+
+### **7.2 Contributor Representation**
+
+By making a Contribution under the applicable contribution process, the Contributor represents, to the extent of their knowledge and authority, that:
+
+* they have the right to submit the Contribution under the applicable terms; or  
+* they are acting with all permissions reasonably required from their employer, institution, or other rights holder; and  
+* the Contribution does not knowingly violate the rights of third parties.
+
+Contributors are not required to represent more than they reasonably know or control.
+
+### **7.3 Institutional Ownership**
+
+If a Contributor’s employer, institution, or other principal owns or controls the relevant rights, the Contribution must be made under a process that is sufficient for RSS to accept and distribute it lawfully. RSS may require confirmation, additional documentation, or a different contribution mechanism in such cases.
+
+## **8\. Rights Granted by Contributions**
+
+### **8.1 Minimum Rights Needed**
+
+Any accepted Contribution must give RSS and downstream users sufficient rights to use, reproduce, modify, distribute, sublicense where applicable under the project license, and otherwise maintain and distribute the Contribution as part of the project.
+
+### **8.2 No Implied Ownership Transfer Unless Specified**
+
+Except where required by law or provided in a separately executed assignment or employment/contractor agreement, acceptance of a Contribution does not by itself mean that RSS or OMSF owns the Contribution.
+
+### **8.3 Separate Assignment or CLA**
+
+For some projects or categories of work, RSS or OMSF may require a contributor license agreement, assignment agreement, or similar instrument. Where such an instrument is used, its terms shall govern to the extent they are consistent with the Charter and applicable law.
+
+## **9\. Consortium-Funded Personnel and Contractors**
+
+### **9.1 Employees and Direct Contractors**
+
+Work created by personnel employed directly by OMSF for RSS, or by contractors engaged directly by OMSF for RSS, shall be governed by the applicable employment or contractor agreement.
+
+Those agreements may provide for ownership by OMSF, assignment to OMSF, or another structure consistent with the Charter and applicable law.
+
+### **9.2 Funded Work in External Institutions**
+
+Where RSS funds work performed in a university, laboratory, institute, or other external organization, ownership and control of resulting work may depend on the governing institutional policy, subaward terms, fellowship terms, consulting agreement, or other applicable arrangement.
+
+In such cases, RSS should seek contract terms sufficient to ensure that resulting work can be released and maintained in a manner consistent with the Charter, even where OMSF does not own the resulting intellectual property.
+
+### **9.3 No Assumption of Ownership**
+
+RSS shall not assume that a participant personally owns work merely because that participant performed the work. Where ownership may lie with an institution or employer, the relevant institutional or contractual framework must be respected.
+
+## **10\. Pre-Existing Materials**
+
+A Contributor or participating institution retains ownership of its pre-existing intellectual property except to the extent rights are expressly licensed or assigned.
+
+A Contribution that incorporates pre-existing materials must be submitted only if the Contributor has authority to include those materials under the applicable project license and contribution process.
+
+Where reasonably practical, pre-existing third-party or institution-owned materials incorporated into a Contribution should be identified in accompanying documentation or repository records.
+
+## **11\. Data, Benchmarks, and Other Non-Code Materials**
+
+Not all Project Materials are software. Some materials may include datasets, benchmarks, test fixtures, images, manuals, tutorials, or other non-code content.
+
+Such materials may be subject to privacy, consent, publication, attribution, database-rights, confidentiality, or other constraints not applicable to software.
+
+RSS may apply project-specific submission standards or additional documentation requirements for these categories of material.
+
+No material should be accepted if RSS lacks a lawful basis to use and distribute it as contemplated by the relevant project.
+
+## **12\. Publications and Scholarly Materials**
+
+Draft manuscripts, figures, supplementary materials, and similar scholarly outputs may relate to Consortium-Funded Projects but need not be treated identically to software Contributions.
+
+Nothing in this Policy authorizes any Member, Sponsor, Partner, or funder to determine scientific conclusions, compel specific scientific findings, or require authors or Developers to misstate technical or scientific results.
+
+Where software and scholarly outputs are developed together, the Release and Publication Policy shall govern timing of public release, and any separate publication-specific authorship or journal obligations shall be respected.
+
+## **13\. Maintainer Authority**
+
+Maintainers and project leadership may review, accept, reject, request changes to, or defer Contributions based on project needs, technical quality, documentation, testing, compatibility, licensing concerns, maintainability, or compliance with applicable project procedures.
+
+Acceptance of a Contribution is not automatic and may be conditioned on the Contributor completing required contribution formalities.
+
+Project leadership may decline a Contribution if there is substantial uncertainty about ownership, licensing, provenance, third-party rights, confidentiality restrictions, or legal compliance.
+
+## **14\. Third-Party Code and Dependencies**
+
+RSS projects may incorporate or depend on third-party open-source software and other externally provided materials only where such use is consistent with the applicable licenses and project goals.
+
+Projects should avoid introducing third-party code or dependencies that would materially compromise RSS’s permissive licensing model unless expressly approved through project governance.
+
+Where required, third-party notices and attribution shall be maintained.
+
+## **15\. Names, Logos, and Branding**
+
+Unless otherwise determined by OMSF or a separate agreement, the names, logos, domains, repository identities, and public branding associated with RSS projects shall be administered as project assets for the benefit of the Consortium and its open-source mission.
+
+Contributors do not obtain ownership of RSS project names, logos, or branding merely by contributing code or other materials.
+
+Use of RSS marks is subject to applicable RSS and OMSF policy.
+
+## **16\. Contributor Attribution**
+
+RSS should provide reasonable attribution practices consistent with open-source norms, repository history, documentation practices, and applicable licenses.
+
+Attribution does not by itself determine legal ownership.
+
+Nothing in this Policy guarantees authorship credit in a scholarly publication, which may depend on separate academic norms and publication-specific decisions.
+
+## **17\. Compliance Concerns and Removal**
+
+If RSS later learns that accepted material may have been contributed without sufficient rights, in breach of confidentiality, in violation of third-party rights, or contrary to law or policy, RSS may take appropriate remedial action, including:
+
+* requesting clarification or additional documentation;  
+* suspending distribution;  
+* replacing or removing the material;  
+* revising repository history where appropriate and feasible;  
+* notifying affected parties where required.
+
+Such action may be taken even after a Contribution has been accepted if necessary to protect RSS, OMSF, contributors, or third parties.
+
+## **18\. Records**
+
+RSS or OMSF should maintain reasonable records of the contribution mechanism used for each project or repository, and of any separate contributor agreements or project-specific contribution requirements.
+
+Project repositories should, where practical, clearly indicate:
+
+* the applicable license;  
+* the applicable contribution process;  
+* any special submission requirements;  
+* any additional provenance or compliance requirements for non-code materials.
+
+## **19\. Exceptions**
+
+Any material exception to this Policy should be documented in writing and approved by the Board or by OMSF where OMSF policy requires.
+
+No exception may authorize treatment of project materials in a manner inconsistent with the Charter’s open-source mission unless compelled by controlling external obligations.
+
+## **20\. Review and Amendment**
+
+The Board may amend this Policy from time to time, consistent with the Charter, OMSF policy, and applicable law.
+
+The Board should review this Policy periodically in light of practical experience, institutional input, contribution practices, and OMSF guidance.
+

--- a/policies/RSS-funding-project-approval-policy.md
+++ b/policies/RSS-funding-project-approval-policy.md
@@ -1,0 +1,150 @@
+## **FUNDING AND PROJECT APPROVAL POLICY**
+
+### **Reciprocal Space Station Consortium**
+
+**Adopted by:** Board of the Reciprocal Space Station Consortium
+**Effective Date:** \[Date\]
+**Administered by:** Open Molecular Software Foundation, as Operating Legal Entity for RSS
+
+This Funding and Project Approval Policy (the "**Policy**") governs how the Reciprocal Space Station Consortium ("**RSS**" or the "**Consortium**") considers, approves, funds, oversees, and reviews Consortium-Funded Projects and related uses of Consortium-administered resources.
+
+This Policy is adopted pursuant to the Charter of RSS (the "**Charter**"). In the event of conflict, the Charter controls over this Policy, and applicable law, OMSF governing documents, and binding external obligations control over both.
+
+## **1\. Scope**
+
+### **1.1 What Requires Formal Board Approval**
+
+Formal Board approval is required for:
+
+* any new Consortium-Funded Project involving material allocation of Consortium-administered funds, personnel, or resources;
+* any material increase in scope, budget, or duration of an existing Consortium-Funded Project;
+* any multi-year commitment not already authorized by the Board;
+* any project-specific arrangement requested by a Member or Partner that goes beyond ordinary membership benefits and support;
+* any allocation subject to the conflict-of-interest provisions of the Charter;
+* any fellowship, subaward, or external institutional arrangement requiring formal approval under Board or OMSF policy;
+* any expenditure category specifically reserved to the Board by the Charter or a Board-approved budget rule.
+
+Routine work performed within an already approved Consortium-Funded Project does not require repeated Board approval unless the project materially changes.
+
+### **1.2 What Does Not Require Formal Board Approval**
+
+Formal Board approval is not required for ordinary operational acts within a Board-approved budget and delegated authority, including, unless otherwise specified:
+
+* routine support to Members consistent with membership benefits;
+* ordinary maintenance, bug fixing, and release management within existing approved workstreams;
+* routine cloud or software-service expenditures within delegated budget authority;
+* ordinary travel, meeting, or minor procurement decisions within delegated limits;
+* small, time-limited exploratory work authorized by the Director within delegated discretion.
+
+The Board may adopt spending thresholds or categories that further clarify this distinction.
+
+No Member, Partner, Developer, Board member, institution, or affiliated laboratory is entitled to receive Consortium funding or project support merely by virtue of participation in RSS.
+
+## **2\. Project Proposal Process**
+
+### **2.1 Who May Propose**
+
+A proposal for a Consortium-Funded Project may be initiated by:
+
+* the Director;
+* one or more Developers;
+* a Board member;
+* a Member or Partner, through the Director or the Board;
+* OMSF staff, where administrative or legal considerations require formalization of a project structure.
+
+### **2.2 Form of Proposal**
+
+A project proposal need not be long, but it must be documented in writing and should ordinarily include:
+
+* project title or working description;
+* purpose and mission alignment;
+* lead Developer or proposed technical lead;
+* expected outputs and beneficiaries;
+* proposed performers or institutions, if known;
+* estimated budget and duration;
+* expected release posture;
+* any known conflicts of interest;
+* any known legal, institutional, or funding constraints.
+
+### **2.3 Role of the Director**
+
+The Director may help shape, prioritize, combine, defer, or refine proposals before Board consideration.
+
+Where a Member or Partner request exceeds ordinary support, the Director should determine whether it is better treated as ordinary support within current operations, a candidate Consortium-Funded Project for Board consideration, or a matter for a separate written arrangement administered by OMSF.
+
+## **3\. Approval**
+
+### **3.1 Required Findings**
+
+Before approving a Consortium-Funded Project, the Board should be satisfied that the project:
+
+* materially advances the Mission or Strategic Goals of RSS;
+* is feasible within available or reasonably anticipated resources;
+* has an identified technical lead or a credible plan to designate one;
+* has a release posture consistent with the Charter;
+* does not create unmanaged conflict-of-interest concerns;
+* is administratively and legally supportable by OMSF; and
+* is worth the expected use of Consortium resources relative to other priorities.
+
+### **3.2 Required Elements**
+
+At the time of approval, or before material work begins, each Consortium-Funded Project should have:
+
+* an approved budget or budget cap;
+* a designated lead Developer or technical lead;
+* a defined funding mechanism or administrative path;
+* a defined reporting expectation, at least annual;
+* any necessary conflict management steps; and
+* any necessary external agreement path identified, if work will be performed outside OMSF.
+
+The Board may approve a project conditionally, provided the conditions are clear and material funding is not disbursed until they are met.
+
+Where a proposed project implicates the conflict-of-interest provisions of the Charter, those provisions apply in full.
+
+## **4\. Budgeting and Spending Authority**
+
+The Board shall approve a high-level budget sufficient to realize the Strategic Goals while ensuring the long-term financial health of RSS, as required by the Charter.
+
+Within a Board-approved budget, the Board may delegate spending authority to the Director for categories or thresholds it defines.
+
+Expenditures outside delegated authority require Board approval.
+
+No project may receive material support unless OMSF or another authorized administrative mechanism can lawfully and practically administer the funding or resource commitment.
+
+## **5\. Funding Mechanisms**
+
+RSS may support approved projects through mechanisms including direct employment through OMSF, contractor agreements, fellowships, subawards, institutional agreements, infrastructure spending, or other lawful and mission-consistent arrangements.
+
+The appropriate mechanism should be selected based on legal feasibility, administrative efficiency, conflict management, institutional constraints, and project needs.
+
+## **6\. Oversight and Reporting**
+
+Unless the Board specifies otherwise, the Director is responsible for day-to-day oversight of approved Consortium-Funded Projects, including tracking scope, budget use, progress, and whether issues should be elevated to the Board.
+
+The Board retains authority to review the status of any Consortium-Funded Project, modify or curtail future support, impose additional reporting, or terminate project support prospectively where justified.
+
+Each Consortium-Funded Project shall provide at least annual reporting to the Board summarizing:
+
+* personnel effort supported by RSS;
+* progress against goals;
+* use of Consortium-administered funds or resources;
+* next steps or remaining milestones; and
+* any material deviation from the approved scope or budget.
+
+## **7\. Changes in Scope, Budget, or Duration**
+
+A Consortium-Funded Project must return to the Board for further approval if there is a material proposed change in scope, budget, duration, lead institution, release posture, conflict profile, or expected outputs.
+
+Minor operational adjustments within approved scope and delegated authority do not require Board action.
+
+## **8\. Suspension or Termination of Projects**
+
+The Board may suspend, terminate, or wind down support for a Consortium-Funded Project where justified by budgetary necessity, mission misalignment, failure to make adequate progress, unresolved compliance or legal concerns, unmanaged conflicts of interest, or strategic reprioritization.
+
+Where feasible, the Board should seek an orderly wind-down that respects existing commitments, project integrity, contributor relationships, and the open-source mission of RSS.
+
+Suspension or termination of support does not by itself determine ownership of resulting work, which remains governed by the Charter and applicable agreements.
+
+## **9\. Review and Amendment**
+
+The Board may amend this Policy from time to time, consistent with the Charter, OMSF policy, and applicable law.

--- a/policies/RSS-release-publication-policy.md
+++ b/policies/RSS-release-publication-policy.md
@@ -1,0 +1,300 @@
+## **RELEASE AND PUBLICATION POLICY**
+
+### **Reciprocal Space Station Consortium**
+
+**Adopted by:** Board of the Reciprocal Space Station Consortium  
+ **Effective Date:** \[Date\]  
+ **Administered by:** Open Molecular Software Foundation, as Operating Legal Entity for RSS
+
+This Release and Publication Policy (the “**Policy**”) governs the release, publication, and limited pre-release handling of Consortium-Funded Work of the Reciprocal Space Station Consortium (“**RSS**” or the “**Consortium**”). It is adopted pursuant to the Charter of RSS (the “**Charter**”).
+
+In the event of conflict, the Charter controls over this Policy, and applicable law, OMSF governing documents, and binding external obligations control over both.
+
+## **1\. Purpose**
+
+RSS is an open-source software consortium for structural biology. This Policy is intended to:
+
+* preserve RSS’s commitment to public release under permissive open-source terms;  
+* allow limited private development where justified;  
+* protect the ability of Consortium participants to publish without being scooped;  
+* ensure that public releases meet reasonable standards of quality, documentation, and usability;  
+* provide a predictable framework for Members’ access to certain pre-release materials;  
+* prevent indefinite delay of public release; and  
+* preserve the technical authority of Developers while allowing Board oversight consistent with the Charter.
+
+## **2\. Scope**
+
+This Policy applies to all **Consortium-Funded Work** and **Consortium-Funded Projects**, as those terms are defined in the Charter.
+
+This Policy does not, by itself, govern purely **External Work** contributed outside Consortium support, except to the extent such work is later incorporated into Consortium-Funded Work or made subject to a project-specific agreement.
+
+## **3\. Governing Principles**
+
+### **3.1 Open Release Principle**
+
+Consortium-Funded Work is intended for public release under permissive terms consistent with the Charter.
+
+### **3.2 No Indefinite Delay**
+
+No Consortium-Funded Work may be withheld from public release indefinitely.
+
+### **3.3 Already-Open Projects Stay Open**
+
+Software that is already public and open-source at the time it receives Consortium support shall remain public and open-source. Consortium support shall not retroactively close or restrict the openness of already-public code, including bug fixes, maintenance, or new features developed in such projects, except to the extent a contributor independently maintains a private development branch pending ordinary public release.
+
+### **3.4 Technical Authority**
+
+Developers retain authority over technical implementation and technical readiness for release.
+
+### **3.5 Limited Role of Membership Benefits**
+
+Pre-release access for Members may be provided as a programmatic benefit, but such access does not create ownership rights, does not control publication or release decisions, and does not entitle Members to privileged access to final scientific conclusions.
+
+### **3.6 Compliance with External Constraints**
+
+Nothing in this Policy overrides applicable law, institutional obligations, grant terms, contract terms, export-control rules, privacy obligations, or other controlling external requirements.
+
+## **4\. Project-Specific Release Policy Required Before Funding**
+
+Before material funding or other administered support is allocated to a Consortium-Funded Project, the Board and the lead Developer for that project shall agree on a **project-specific release policy** consistent with the Charter and this Policy.
+
+The project-specific release policy shall be documented in writing and shall identify, as appropriate:
+
+* the project title or description;  
+* the lead Developer for release-readiness purposes;  
+* the expected categories of outputs;  
+* whether limited private development is anticipated;  
+* expected publication or release milestones;  
+* whether Member pre-release access is anticipated and, if so, for what categories of materials;  
+* any project-specific considerations affecting timing of release; and  
+* any known external constraints that may affect release.
+
+The project-specific release policy may be brief, but it must be sufficiently clear to allow the Board, Director, and Developers to understand the expected release path before support begins.
+
+## **5\. Categories of Materials**
+
+For purposes of administration under this Policy, Consortium-Funded Work may include one or more of the following:
+
+* source code;  
+* binaries or packages;  
+* internal builds;  
+* test datasets;  
+* documentation;  
+* tutorials or training materials;  
+* benchmarks;  
+* technical notes;  
+* manuscripts or draft publications;  
+* infrastructure or deployment materials.
+
+Different categories of material may appropriately be treated differently under a project-specific release policy. For example, source code and documentation may be released on a different schedule from a manuscript draft or benchmark dataset, so long as the treatment remains consistent with the Charter and this Policy.
+
+## **6\. Limited Private Development**
+
+### **6.1 Permitted Reasons**
+
+Specific items of Consortium-Funded Work may be held in private repositories or otherwise withheld from immediate public release for a limited period for reasons including:
+
+* protecting the ability of Consortium researchers to publish their findings without being scooped;  
+* allowing time to reach reasonable standards of quality, testing, and documentation;  
+* coordinating a planned release across related software components;  
+* allowing internal evaluation and feedback by Members where permitted under policy;  
+* managing responsible disclosure of security-sensitive issues; or  
+* complying with external legal, institutional, or funding obligations.
+
+### **6.2 Presumption Against Overuse**
+
+Limited private development is a tool for responsible release management, not a substitute for RSS’s open-source mission. It should be used only where justified by project needs or external obligations.
+
+## **7\. Release-Ready Determination**
+
+### **7.1 Lead Developer Role**
+
+Each Consortium-Funded Project shall identify a **lead Developer** responsible for making the initial release-ready determination for that project or for particular outputs within that project.
+
+### **7.2 Standard for Release Readiness**
+
+A release-ready determination is a good-faith technical assessment that a specific item of Consortium-Funded Work is sufficiently mature for public release, taking into account the nature of the work and the project-specific release policy.
+
+Release-readiness does not require perfection. It requires that, in the judgment of the lead Developer:
+
+* the work is sufficiently functional for its intended public release;  
+* known limitations are reasonably understood;  
+* documentation is adequate for the intended release context, if documentation is appropriate to the work;  
+* release would be consistent with the project-specific release policy, unless a justified deviation is identified; and  
+* no unresolved issue is known that would make public release materially irresponsible in context.
+
+### **7.3 Documentation of Release-Ready Determination**
+
+When the lead Developer determines that work is release-ready, the lead Developer shall communicate that determination to the Director in writing.
+
+The written notice should identify:
+
+* the relevant project;  
+* the item or category of work deemed release-ready;  
+* the date of the determination;  
+* the basis for the determination in brief;  
+* any requested delay in release and the reason for it, if applicable; and  
+* any known external constraint affecting release.
+
+Email or comparable written project records are sufficient.
+
+## **8\. Director’s Procedural Good-Faith Check**
+
+The Director’s role is limited to a **procedural check** of whether the lead Developer’s release-ready determination was made in good faith and with reasonable documentation.
+
+The Director shall not substitute their own technical judgment for that of the lead Developer except as expressly required by a Board-approved policy governing process.
+
+The Director may request clarification, additional documentation, or confirmation that the release-ready determination is consistent with the project-specific release policy.
+
+If the Director concludes that the release-ready determination was made in good faith and is reasonably documented, the Director shall record the determination date for purposes of this Policy.
+
+If the Director concludes that the determination was not made in good faith or is materially undocumented, the Director shall notify the lead Developer promptly in writing, stating the basis for that procedural concern. The lead Developer may then revise or supplement the submission.
+
+A disagreement between the Director and lead Developer about the procedural sufficiency of a determination may be referred to the Board for resolution, but the Board remains bound by the Charter’s allocation of technical authority.
+
+## **9\. Maximum Delay Rule**
+
+### **9.1 Default Maximum Delay**
+
+The default maximum delay for public release of Consortium-Funded Work is **six (6) months** from the date on which the lead Developer determines in good faith that the work is technically ready for release and communicates that determination to the Director in accordance with this Policy.
+
+### **9.2 Shorter Project-Specific Timelines**
+
+A project-specific release policy may adopt shorter expected timelines or target release windows.
+
+### **9.3 No Longer Timelines Except for External Requirements**
+
+A project-specific release policy may not exceed the default six-month maximum delay unless a longer period is required by:
+
+* applicable law;  
+* binding institutional obligations;  
+* grant or contract terms;  
+* export-control or sanctions rules;  
+* privacy, security, or confidentiality obligations;  
+* other controlling external requirements.
+
+Any such longer delay should be no broader and no longer than reasonably necessary.
+
+### **9.4 Effect of the Maximum Delay**
+
+Absent a controlling external requirement, work that has reached the six-month maximum delay must be authorized for public release.
+
+## **10\. Board Role in Release Delay**
+
+The Board may, in furtherance of the Mission, approve a limited delay in the public release of specific Consortium-Funded Work, provided that:
+
+* the delay is justified;  
+* the delay is consistent with the project-specific release policy and this Policy;  
+* the delay does not exceed the six-month maximum unless an external requirement controls; and  
+* the reasons for delay are documented in Board records.
+
+Examples of permissible Board-approved delay grounds include coordination with a planned publication, a major documentation or packaging milestone, or a short period needed to complete a coherent public release.
+
+The Board should not use its delay authority to suppress technically ready work for reasons unrelated to the Mission or to provide de facto permanent private access to Members or other parties.
+
+## **11\. Developer Review of Extended Delay**
+
+If the public release of work is delayed beyond what the lead Developer believes is justified under the project-specific release policy or this Policy, the lead Developer or any two Developers involved in the relevant project may request Board review.
+
+Upon such request, the Board shall promptly review the delay and provide a written decision or recorded resolution stating:
+
+* whether the delay will continue;  
+* the justification for the continued delay; and  
+* the planned release date or release condition, if known.
+
+The Board’s review must remain consistent with the six-month maximum delay rule and the Charter.
+
+## **12\. Member Access to Pre-Release Materials**
+
+### **12.1 Permitted Access**
+
+Members may be granted access to certain pre-release materials as a membership benefit where provided under the Membership Agreement, membership schedule, project-specific release policy, or Board-approved practice.
+
+Pre-release access may include, as appropriate:
+
+* unstable internal builds;  
+* draft documentation;  
+* limited roadmap or technical discussion materials;  
+* deployment guidance related to pre-release software;  
+* other non-public materials suitable for internal evaluation and feedback.
+
+### **12.2 Limits on Member Access**
+
+Member access is subject to all applicable confidentiality obligations and is limited to internal evaluation, testing, feedback, and related internal purposes.
+
+Member pre-release access does not imply:
+
+* ownership of Consortium-Funded Work;  
+* control over release timing;  
+* privileged access to final scientific conclusions as such;  
+* guaranteed support beyond the Membership Agreement;  
+* any right to disclose or redistribute non-public materials.
+
+### **12.3 Differential Access by Tier**
+
+Board-approved membership policies may provide different levels of pre-release access or engagement for different membership tiers, provided that such differences remain consistent with the Charter and do not undermine RSS’s open-source mission.
+
+## **13\. Publications**
+
+RSS recognizes that publications, preprints, and related scholarly outputs may accompany Consortium-Funded Work.
+
+Nothing in this Policy authorizes any Member, Sponsor, Partner, or funder to determine scientific conclusions, compel specific scientific findings, or require authors or Developers to misstate technical or scientific results.
+
+Where a project-specific release policy contemplates coordinated publication and code release, the Board and lead Developer should seek a release schedule that:
+
+* protects legitimate academic publication interests;  
+* avoids unnecessary withholding of technically ready work;  
+* respects external obligations; and  
+* remains consistent with the six-month maximum delay rule unless an external requirement controls.
+
+## **14\. Security, Privacy, and Sensitive Materials**
+
+Nothing in this Policy requires RSS to release:
+
+* private personal data;  
+* confidential third-party material that RSS lacks authority to disclose;  
+* security-sensitive details whose disclosure would create a material and unreasonable risk;  
+* information restricted by law, contract, or binding institutional obligation.
+
+Where feasible, RSS should seek to release a redacted, sanitized, or otherwise appropriately limited version of such material rather than withholding unrelated work more broadly than necessary.
+
+## **15\. Annual Reporting**
+
+Each Consortium-Funded Project shall provide at least annual reporting to the Board, in a form determined by Board policy, summarizing:
+
+* personnel effort supported by the Consortium;  
+* progress made during the reporting period;  
+* use of Consortium-administered funds or resources;  
+* anticipated next steps or remaining milestones; and  
+* any significant release or publication issues encountered during the reporting period.
+
+The Board may require additional reporting for particular projects where warranted by scale, risk, conflict-of-interest considerations, or external obligations.
+
+## **16\. Records**
+
+The Director shall maintain reasonable records sufficient to document:
+
+* project-specific release policies;  
+* release-ready determinations;  
+* Director procedural determinations under this Policy;  
+* Board decisions to delay release;  
+* any invocation of an external requirement justifying delay beyond six months; and  
+* any Developer request for Board review of extended delay.
+
+These records may be maintained in meeting minutes, project files, email records, or other ordinary governance records.
+
+## **17\. Exceptions**
+
+Any exception to this Policy must be:
+
+* consistent with the Charter;  
+* documented in writing; and  
+* approved by the Board, unless the exception is compelled by external law or binding external obligation.
+
+No exception may authorize indefinite withholding of Consortium-Funded Work except to the extent release is genuinely barred by a controlling external requirement.
+
+## **18\. Review and Amendment**
+
+The Board may amend this Policy from time to time, consistent with the Charter and OMSF policy.
+
+The Board should review this Policy periodically in light of practical experience, sponsor relationships, publication practices, and institutional feedback.


### PR DESCRIPTION
## Draft Board-approved policies and charter refinements

To ensure that the Charter remains constitutional, and not cluttered or overly detailed, the following concepts considered as part of the drafting process were split off into discrete policies that could be adopted by the Board at a later date. Until a first Board exists and approves them, they remain starting points for future discussion.