### PR TITLE
explicit policies & resolutions

### DIFF
--- a/RSS-charter.md
+++ b/RSS-charter.md
@@ -176,7 +176,7 @@ Approve amendments to this Charter, initiate or approve dissolution of the Conso
 Approve, under the Conflict of Interest provisions of this Charter, any expenditure or allocation materially benefiting the institution, laboratory, research group, or closely related project of a sitting Board member or the Director.
 
 **J. Adoption of Policies.**  
-The Board may adopt, amend, and repeal written policies to direct the work of the Consortium on any matter within its authority, including but not limited to release and publication, contributions and intellectual property, membership and partnership rights and obligations, and funding and project approval. All Board-approved policies shall be made available to Members and Developers.
+The Board may adopt, amend, and repeal written policies to direct the work of the Consortium on any matter within its authority, including but not limited to release and publication, contributions and intellectual property, membership and partnership rights and obligations, and funding and project approval. All Board-approved policies must be consistent with this Charter; in the event of conflict, this Charter controls. All Board-approved policies shall be made available to Members and Developers.
 
 Beyond these duties, all authorities not otherwise specified in this Charter are the prerogative of the Board. To the extent it does not conflict with this Charter, the Board may delegate and revoke authorities to the Director, a Developer, a committee, or another representative.
 

--- a/RSS-charter.md
+++ b/RSS-charter.md
@@ -258,7 +258,19 @@ The Developers retain primary responsibility for technical implementation, codin
 
 The Board may set priorities, budgets, and high-level release policy, but shall not micromanage ordinary technical implementation.
 
-### **5.3 Composition**
+### **5.3 Developer Resolutions**
+
+The Developers may adopt written Resolutions on matters within their authority, including coding practices, review standards, testing requirements, documentation norms, tooling, communication, internal organization, community building, and related engineering or operational concerns.
+
+A Resolution shall be adopted by majority vote of participating Developers, provided that a quorum of at least two-thirds (2/3) of current Developers are present or participate.
+
+Resolutions are non-binding recommendations that document the consensus of the Developers.
+
+However, upon adoption of a Resolution, the Developers may by the same or a subsequent vote recommend that the Board adopt the substance of the Resolution as a binding Board-approved policy under Section 4.3. The Board shall consider any such recommendation in a timely manner but is not obligated to adopt it.
+
+Adopted Resolutions and their current status shall be maintained as Consortium records by the Director.
+
+### **5.4 Composition**
 
 Membership in the group of Developers is intended to reflect active contributions to the Consortium.
 
@@ -273,7 +285,7 @@ Votes must be conducted electronically in a manner accessible worldwide, and vot
 
 A public list of current Developers shall be maintained by the Director and made available to the Developers and Board.
 
-### **5.4 Developer Elections to the Board**
+### **5.5 Developer Elections to the Board**
 
 Board members elected by the Developers shall be elected through an approval voting process using secret ballots.
 
@@ -283,13 +295,13 @@ Each Developer shall receive a ballot listing all eligible candidates and may ca
 
 The three candidates receiving the greatest number of approvals shall be declared elected to the Board. In the event of a tie for the final seat, a runoff election shall be held in which each Developer casts a single vote. If a tie remains, the Chair of the Board shall cast the tie-breaking vote, unless recused, in which case the tied seat shall remain vacant until a further runoff can be conducted.
 
-### **5.5 Dissolution Right of the Developers**
+### **5.6 Dissolution Right of the Developers**
 
 The Developers retain the right to dissolve the Consortium and nullify this Charter.
 
 If at any time two-thirds (2/3) or more of all sitting Developers vote in favor of dissolution, the Board must make arrangements for the cessation of operations in accordance with Article 11\.
 
-### **5.6 Resources of the Developers**
+### **5.7 Resources of the Developers**
 
 It is explicitly recognized that the Consortium may make resources available to the Developers to empower them to execute their role within the Consortium. The Board may therefore allocate budget for software services, travel, compute, collaboration tools, and other material resources that Developers will be eligible to use.
 

--- a/RSS-charter.md
+++ b/RSS-charter.md
@@ -166,17 +166,17 @@ Review and approve hiring recommendations made by the Director, unless the Board
 **F. Membership Framework.**  
 Establish membership categories, participation rights, general benefit structures, and related policies or agreements.
 
-**G. Release and Publication Policy.**  
-Adopt policies governing the timing and conditions of release and publication for Consortium-Funded Work, consistent with Article 8\.
-
-**H. Conflict Resolution and Governance.**  
+**G. Conflict Resolution and Governance.**  
 Resolve conflicts of interest, disputes among Consortium participants, and other governance matters using the powers vested in the Board by this Charter.
 
-**I. Charter Amendment, Separation, and Dissolution.**  
+**H. Charter Amendment, Separation, and Dissolution.**  
 Approve amendments to this Charter, initiate or approve dissolution of the Consortium, and act on separation matters as provided elsewhere in this Charter.
 
-**J. Approval of Insider-Connected Allocations.**  
+**I. Approval of Insider-Connected Allocations.**  
 Approve, under the Conflict of Interest provisions of this Charter, any expenditure or allocation materially benefiting the institution, laboratory, research group, or closely related project of a sitting Board member or the Director.
+
+**J. Adoption of Policies.**  
+The Board may adopt, amend, and repeal written policies to direct the work of the Consortium on any matter within its authority, including but not limited to release and publication, contributions and intellectual property, membership and partnership rights and obligations, and funding and project approval. All Board-approved policies shall be made available to Members and Developers.
 
 Beyond these duties, all authorities not otherwise specified in this Charter are the prerogative of the Board. To the extent it does not conflict with this Charter, the Board may delegate and revoke authorities to the Director, a Developer, a committee, or another representative.
 
@@ -472,7 +472,7 @@ If recusals would prevent quorum, the non-conflicted Board members may seek addi
 
 Any expenditure, grant, fellowship, contract, or other allocation materially benefiting the institution, laboratory, research group, or closely related project of a sitting Board member or the Director shall require explicit Board approval with the conflicted individual recused.
 
-The Board may require reasonable reporting, certification, or progress documentation for such allocations. At a minimum, any such allocation made through a Consortium-Funded Project remains subject to the annual reporting requirement in Section 8.7.
+The Board may require reasonable reporting, certification, or progress documentation for such allocations. At a minimum, any such allocation made through a Consortium-Funded Project remains subject to the annual reporting requirement in Section 8.8.
 
 ### **9.6 Enforcement**
 


### PR DESCRIPTION
This PR makes two functions explicit, rather than implicit:
1. The Board can adopt written policies that govern the Consortium. E.g. release policy, etc.
2. The Developers can adopt non-binding Resolutions. Imagine coding practices, but also community engagement things. They can recommend these to the Board, who can making them binding Policies if appropriate. But I suspect just writing small things down will help align folks.

 This way the Charter doesn't need to do all the work, it just sets the framework.