### PR TITLE
lower bar for amendment

### DIFF
--- a/RSS-charter.md
+++ b/RSS-charter.md
@@ -576,7 +576,7 @@ The Consortium shall maintain a public or participant-accessible record of curre
 
 Any amendment of this Charter shall require:
 
-**A.** the affirmative vote of all Board members then in office; followed by  
+**A.** the affirmative vote of a majority of Board members then in office; followed by  
 **B.** the affirmative vote of two-thirds (2/3) of the Developers.
 
 Upon adoption of any amendment to this Charter, the Director shall archive the prior version of the Charter and record the date of amendment, the nature of the changes made, and the vote by which the amendment was approved.


### PR DESCRIPTION
This change would address the final point (no. 5) in #8. The question on the virtual table is: what should be required to amend the Charter?

- Previously we had: unanimous board vote + 2/3 of developers
- Possible suggestion: majority board vote + 2/3 developers

I will say I prefer the current version (unanimous board vote required)

The Consortium can be dissolved by a majority Board vote or vote of 2/3 of Developers. The latter is intentionally powerful -- it is basically the only unilateral power the Developers have that isn't executed through the board. It is the one big check they have on the Board's power. Remember though half the Board are Devs.

@DHekstra says it should be easier to amend the Charter than dissolve, but I disagree. I see the ability to blow things up as a threat no one wants, so it can act as a mechanism to keep things in line.

That said, amendments will probably be important, especially in the early days. It shouldn't be impossible.

What do you guys think?