### PR TITLE
Partner board seat revision

### DIFF
--- a/RSS-charter.md
+++ b/RSS-charter.md
@@ -21,11 +21,11 @@ To advance its mission, the Consortium may undertake education, knowledge curati
 
 The Consortium shall be composed of three bodies, together tasked with carrying out the Mission, and an Operating Legal Entity that provides their legal and administrative framework:
 
-**A. The Member Institutions (“Members”).**  
-The Members are typically companies, universities, research institutes, or comparable organizations that enter into a membership agreement with the Consortium. Members provide financial resources, strategic input, and external perspective in exchange for governance participation, support, and programmatic benefits as provided in this Charter, applicable membership agreements, and Board-approved policies.
+**A. The Partner Institutions (“Partners”).**  
+The Partners are typically companies, universities, research institutes, or comparable organizations that enter into a partnership agreement with the Consortium. Partners provide financial resources, strategic input, and external perspective in exchange for governance participation, support, and programmatic benefits as provided in this Charter, applicable partnership agreements, and Board-approved policies.
 
 **B. A Governing Board (the “Board”).**  
-The Board is the primary governing body of the Consortium, tasked with setting strategic direction, setting a budget, conducting oversight, approving major allocations of Consortium resources, and resolving internal disputes. The Board consists of elected representatives of the Developers and Members. Each respective group elects its own representatives.
+The Board is the primary governing body of the Consortium, tasked with setting strategic direction, setting a budget, conducting oversight, approving major allocations of Consortium resources, and resolving internal disputes. The Board consists of representatives of the Partners and the Developers. The Developers elect their own representatives; the Partner representatives are seated according to their contributions to the Consortium, as provided in this Charter.
 
 **C. The Developers.**  
 The Developers are a self-governing body of researchers and engineers who actively work to further the strategic goals set by the Board and execute the Mission of the Consortium. Developers participate as individuals and do not necessarily represent any institution. The group may include, for example, staff employed by the Consortium, Consortium-funded fellows based at academic institutions, and volunteer community members who have no contractual obligation to the Consortium. The Developers self-elect representatives to the Board. One Developer is appointed by the Board to act as Director, tasked with ensuring that Consortium resources are used to uphold the Mission and execute the Board's strategy.
@@ -40,47 +40,43 @@ Unless expressly designated otherwise in a separate written agreement, Developer
 
 No person acting under this Charter may bind any university, laboratory, company, government entity, or other institution absent separate written authority.
 
-As provided for in Articles 3 and 5 respectively, an individual may simultaneously serve as both a Developer and as a designated representative of a Member, subject to any applicable conflict-of-interest provisions of this Charter.
+As provided for in Articles 3 and 5 respectively, an individual may simultaneously serve as both a Developer and as a designated representative of a Partner, subject to any applicable conflict-of-interest provisions of this Charter.
 
 Nothing in this Charter shall be construed to override the policies, contractual obligations, or legal constraints applicable to any participant by virtue of their employment, appointment, grant support, or institutional affiliation.
 
-## **ARTICLE 3\. Membership**
+## **ARTICLE 3\. Partnership**
 
-### **3.1 The Role of the Member Institutions**
+### **3.1 The Role of the Partner Institutions**
 
-Member institutions (“Members”) are the entities — typically companies, universities, research institutes or comparable organizations — that resource the Consortium and enable it to carry out its Mission. Through their participation, Member institutions obtain the right to influence and obtain early access the Consortium's work. Each Member is bound by a membership agreement with the Consortium that defines its financial obligations, rights, and benefits. Through the governance mechanisms established by this Charter, Members provide strategic input that shapes the direction and priorities of the Consortium.
+Partner institutions (“Partners”) are the entities — typically companies, universities, research institutes or comparable organizations — that resource the Consortium and enable it to carry out its Mission. Through their participation, Partner institutions obtain the right to influence and obtain early access the Consortium's work. Each Partner is bound by a partnership agreement with the Consortium that defines its financial obligations, rights, and benefits. Through the governance mechanisms established by this Charter, Partners provide strategic input that shapes the direction and priorities of the Consortium.
 
-### **3.2 Membership Categories**
+### **3.2 Partnership Terms**
 
-The Consortium may establish two tiers of membership, designated by the Board as **Members** and **Partners**, with Partners contributing additional resources to the consortium.
+The Consortium recognizes a single class of partner participant, designated by the Board as **Partners**.
 
-The Board may define, revise, and publish the financial contribution levels, standard benefits, and administrative conditions associated with each tier through Board-approved policies or participation agreements administered by the Operating Legal Entity.
+The Board may define, revise, and publish the financial contribution levels, standard benefits, and administrative conditions of partnership through Board-approved policies or participation agreements administered by the Operating Legal Entity.
 
-The Consortium may also enter into project-specific, grant-specific, sponsorship-specific, or other limited arrangements that do not create continuing membership or governance rights unless expressly provided.
+The Consortium may also enter into project-specific, grant-specific, sponsorship-specific, or other limited arrangements that do not create continuing partnership or governance rights unless expressly provided.
 
-### **3.3 General Rights of Members**
+### **3.3 Rights of Partners**
 
-Each Member in Good Standing shall have the right to:
+Each Partner in Good Standing shall have the right to:
 
 **A.** designate one representative, by whatever internal mechanism it chooses, to participate in Consortium business on its behalf;
 
-**B.** send at least one voting representative to the Annual Meeting of the Consortium;
+**B.** send at least one representative to the Annual Meeting of the Consortium;
 
-**C.** vote in the annual election of Member-elected seats on the Board, as provided in this Charter;
+**C.** be considered for a Partner seat on the Board according to its contributions to the Consortium, as provided in Section 4.5;
 
 **D.** recommend strategic directions, projects, features, educational materials, or other priorities to the Board at any time;
 
 **E.** receive such support, communication channels, pre-release access, recognition, or other programmatic benefits as may be provided in Board-approved policies or agreements.
 
-### **3.4 Additional Rights of Partners**
+### **3.4 Nature of Partnership Benefits**
 
-Partners retain all rights of Members. In addition, reflecting their increased contributions and commitment to the Consortium, the representative of a Partner institution is eligible for election to a Member-elected Board seat.
+Partnership provides meaningful influence over Consortium priorities and funding allocations through the governance mechanisms established by this Charter, including the seating of Partner representatives on the Board according to their contributions.
 
-### **3.5 Nature of Membership Benefits**
-
-Membership provides meaningful influence over Consortium priorities and funding allocations through the governance mechanisms established by this Charter, including the election of Member representatives to the Board.
-
-Membership does not confer:
+Partnership does not confer:
 
 **A.** ownership of Consortium intellectual property;
 
@@ -90,41 +86,41 @@ Membership does not confer:
 
 **D.** authority to direct release, publication, or licensing decisions except as expressly provided in this Charter or in Board-approved policy.
 
-The detailed economic and programmatic terms of membership, including contribution amounts, support expectations, and pre-release access terms, may be set forth in separate policies or agreements.
+The detailed economic and programmatic terms of partnership, including contribution amounts, support expectations, and pre-release access terms, may be set forth in separate policies or agreements.
 
-### **3.6 Good Standing**
+### **3.5 Good Standing**
 
-A Member shall be considered in Good Standing if:
+A Partner shall be considered in Good Standing if:
 
-**A.** all membership fees or other required payments due to the Consortium have been paid in full and on time;
+**A.** all partnership fees or other required payments due to the Consortium have been paid in full and on time;
 
-**B.** the Member has not materially breached any provision of this Charter or any applicable participation agreement;
+**B.** the Partner has not materially breached any provision of this Charter or any applicable participation agreement;
 
-**C.** no unresolved finding of violation has been issued against the Member by the Board under any applicable provision of this Charter.
+**C.** no unresolved finding of violation has been issued against the Partner by the Board under any applicable provision of this Charter.
 
-A Member that fails to satisfy condition (A) shall be given written notice by the Director and a grace period of thirty (30) days in which to cure the delinquency before losing Good Standing.
+A Partner that fails to satisfy condition (A) shall be given written notice by the Director and a grace period of thirty (30) days in which to cure the delinquency before losing Good Standing.
 
-Loss of Good Standing shall result in suspension of membership rights for the duration of the delinquency, except to the extent otherwise required by applicable law or contract.
+Loss of Good Standing shall result in suspension of partnership rights for the duration of the delinquency, except to the extent otherwise required by applicable law or contract.
 
-The Board may, by majority vote, reinstate a Member to Good Standing upon satisfaction of all outstanding obligations.
+The Board may, by majority vote, reinstate a Partner to Good Standing upon satisfaction of all outstanding obligations.
 
-### **3.7 Voluntary Withdrawal**
+### **3.6 Voluntary Withdrawal**
 
-A Member may voluntarily withdraw from the Consortium at any time by providing written notice to any Board member or the Director.
+A Partner may voluntarily withdraw from the Consortium at any time by providing written notice to any Board member or the Director.
 
 Upon withdrawal:
 
-**A.** membership fees already paid shall not be refunded, except as required by applicable law or the terms of any individual participation agreement;
+**A.** partnership fees already paid shall not be refunded, except as required by applicable law or the terms of any individual participation agreement;
 
 **B.** amounts outstanding at the time of withdrawal remain due and payable;
 
-**C.** membership rights and benefits shall cease upon the effective date of withdrawal, except as otherwise provided by contract;
+**C.** partnership rights and benefits shall cease upon the effective date of withdrawal, except as otherwise provided by contract;
 
-**D.** any Board seat held by a representative of the withdrawing Partner-level Member shall be treated as a vacancy under Section 4.6;
+**D.** any Board seat held by a representative of the withdrawing Partner shall be treated as a vacancy under Section 4.6;
 
 **E.** pre-release access rights shall terminate upon withdrawal unless otherwise provided by contract;
 
-**F.** withdrawal does not relieve the Member of obligations incurred prior to the effective date of withdrawal.
+**F.** withdrawal does not relieve the Partner of obligations incurred prior to the effective date of withdrawal.
 
 ## **ARTICLE 4\. The Board**
 
@@ -140,16 +136,18 @@ Board appointments are strictly unpaid positions, except that the Consortium may
 
 The Board shall consist of six members:
 
-**A.** three elected representatives of Partner-level Members; and  
+**A.** three representatives of Partner institutions, seated according to their contributions to the Consortium as provided in Section 4.5; and  
 **B.** three elected representatives of the Developers.
 
-These seats shall be elected by the Members and Developers, respectively, at or in advance of the Annual Meeting.
+The three Partner seats are individually designated Seat P1, Seat P2, and Seat P3. Each Partner seat carries a three-year term, and the terms are staggered so that the term of exactly one Partner seat comes up for assignment each year. The schedule by which each Partner seat's term expires is established under the Adoption provisions of this Charter, and each seat is filled as provided in Section 4.5.
 
-Board members serve one-year terms and may be reelected without term limit. No individual may hold more than one Board seat at a time. An individual who is eligible for both a Member-elected and a Developer-elected seat must choose one election to participate in.
+The three Developer-elected seats are elected by the Developers at or in advance of the Annual Meeting and serve one-year terms.
 
-If the Consortium consists of fewer than three willing Partner-level Members or fewer than three willing Developers, seats on the Board may remain unfilled.
+Board members may be reelected or reassigned without term limit. No individual may hold more than one Board seat at a time, and no Partner institution may hold more than one Partner seat at a time. An individual who is eligible for both a Partner seat and a Developer-elected seat must choose one to hold.
 
-One member of the Board shall be designated as Chair. The Chair shall be elected by majority vote of the Board at the first meeting following each Annual Meeting and shall serve a one-year term concurrent with their Board term. A Board member may serve as Chair for no more than two consecutive terms.
+If the Consortium consists of fewer than three willing Partner institutions or fewer than three willing Developers, seats on the Board may remain unfilled.
+
+One member of the Board shall be designated as Chair. The Chair shall be elected by majority vote of the Board at the first meeting following each Annual Meeting and shall serve a one-year term, provided the Chair remains a sitting Board member for its duration. A Board member may serve as Chair for no more than two consecutive terms.
 
 The Chair shall set agendas, convene and preside over Board meetings, put matters to a vote, and ensure the Board operates in accordance with this Charter. The Chair shall schedule Board meetings, in a physical, virtual, or hybrid format, providing at least thirty (30) days' notice to all Board members. The Chair may call meetings _ad hoc_ to handle urgent or emergency business.
 
@@ -160,7 +158,7 @@ With consent of the Board by majority vote, the Chair may appoint additional off
 The Board has the express charge to carry out the following duties, which shall not be delegated except where explicitly specified elsewhere in this Charter:
 
 **A. Strategic Goals.**  
-Set Strategic Goals for the Consortium. The Board shall integrate input from the Members, Developers, and broader community to set the overall scientific and engineering direction of the Consortium. No less than once a year, the Board shall present the Director with a clear document, in any format, detailing the Strategic Goals for the Consortium. A copy of this document shall be made available to the other Consortium participants.
+Set Strategic Goals for the Consortium. The Board shall integrate input from the Partners, Developers, and broader community to set the overall scientific and engineering direction of the Consortium. No less than once a year, the Board shall present the Director with a clear document, in any format, detailing the Strategic Goals for the Consortium. A copy of this document shall be made available to the other Consortium participants.
 
 **B. Budget and Fiduciary Responsibility.**  
 Develop and approve a clear, high-level budget sufficient to realize the Strategic Goals while ensuring the long-term financial health of the Consortium.
@@ -174,8 +172,8 @@ Approve major expenditures, major Consortium-Funded Projects, multi-year financi
 **E. Hiring Approval.**  
 Review and approve hiring recommendations made by the Director, unless the Board has delegated such approval in advance for a specified role or spending category.
 
-**F. Membership Framework.**  
-Establish membership categories, participation rights, general benefit structures, and related policies or agreements.
+**F. Partnership Framework.**  
+Establish partnership terms, participation rights, general benefit structures, and related policies or agreements.
 
 **G. Conflict Resolution and Governance.**  
 Resolve conflicts of interest, disputes among Consortium participants, and other governance matters using the powers vested in the Board by this Charter.
@@ -187,7 +185,7 @@ Approve amendments to this Charter, initiate or approve dissolution of the Conso
 Approve, under the Conflict of Interest provisions of this Charter, any expenditure or allocation materially benefiting the institution, laboratory, research group, or closely related project of a sitting Board member or the Director.
 
 **J. Adoption of Policies.**  
-The Board may adopt, amend, and repeal written policies to direct the work of the Consortium on any matter within its authority, including but not limited to contributions and intellectual property, membership and partnership rights and obligations, and funding and project approval. All Board-approved policies must be consistent with this Charter; in the event of conflict, this Charter controls. All Board-approved policies shall be made available to Members and Developers.
+The Board may adopt, amend, and repeal written policies to direct the work of the Consortium on any matter within its authority, including but not limited to contributions and intellectual property, partnership rights and obligations, and funding and project approval. All Board-approved policies must be consistent with this Charter; in the event of conflict, this Charter controls. All Board-approved policies shall be made available to Partners and Developers.
 
 Beyond these duties, all authorities not otherwise specified in this Charter are the prerogative of the Board. To the extent it does not conflict with this Charter, the Board may delegate and revoke authorities to the Director, a Developer, a committee, or any other representative.
 
@@ -203,27 +201,32 @@ Any Board member may request a deliberation period of up to fourteen (14) days b
 
 All decisions shall be recorded in meeting minutes.
 
-### **4.5 Election of Member Representatives to the Board**
+### **4.5 Assignment of Partner Representatives to the Board**
 
-Board members elected by the Members shall be elected through an approval voting process using secret ballots.
+The three Partner seats (Seats P1, P2, and P3) are filled by reference to the contributions that Partner institutions have made and committed to the Consortium, rather than by election.
 
-Each Member in Good Standing shall cast one ballot through its designated representative.
+**A. Annual assignment cycle.** The term of exactly one Partner seat comes up for assignment each year. The assignment for the seat then coming up shall be confirmed at the last regular Board meeting before the Annual Meeting, and the assigned representative shall be seated no later than the close of the Annual Meeting. The date of that Board meeting fixes the accounting period used to evaluate contributions under paragraph C.
 
-Only representatives of Partner institutions are eligible to stand for Member-elected Board seats. 
+**B. Eligibility by contribution.** When a Partner seat comes up, the Partner institution in Good Standing that has made the largest contribution to the Consortium becomes eligible to fill the seat through its designated representative. Because no Partner may hold more than one Partner seat at a time, a Partner that holds another Partner seat whose term is not then expiring is not eligible; the Partner whose representative holds the expiring seat, however, remains eligible to be reassigned to it. A Partner may decline to be seated, in which case eligibility passes to the next-largest eligible contributor.
 
-Unless they proactively recuse themselves, all Partner institutions shall be considered for a board seat in the vote.
+**C. Measurement of contribution.** A Partner's contribution shall be evaluated quantitatively as a single monetary value, comprising:
 
-Each eligible Member shall receive a ballot listing all eligible candidates and may cast a vote in favor of any number of candidates it deems qualified to serve on the Board.
+**i.** cash contributions, valued at their face amount; and  
+**ii.** in-kind contributions, such as engineering hours and compute, valued at eighty percent (80%) of their fair cash-equivalent value (for example, $100,000 of donated engineering time counts as $80,000).
 
-The three candidates receiving the greatest number of approvals shall be declared elected to the Board. In the event of a tie for the final seat, a runoff election shall be held in which each eligible Member casts a single vote. If a tie remains, the sitting Chair of the Board shall cast the tie-breaking vote.
+The contribution shall be measured over a three-year window, consisting of the realized contributions of the two years preceding the accounting period fixed under paragraph A together with the contribution promised for the year following that accounting period, the latter computed at the Partner's current contribution rate. The Board shall determine the fair cash-equivalent value of in-kind contributions in good faith and may adopt a policy under Section 4.3.J governing how contributions are documented and valued.
+
+**D. Ratification by the Board.** The assignment of an eligible Partner to a Partner seat must be ratified by the sitting Board. The assignment is ratified unless all sitting Board members vote to reject it. Upon such a unanimous vote to reject, eligibility passes to the next-largest contributor under paragraphs B and C, and the ratification process repeats. This unanimity requirement governs notwithstanding the recusal and quorum provisions of Section 9.4.
+
+**E. Initial assignment before all Partner seats are filled.** While one or more Partner seats remain unoccupied, the sitting Board may, at any time and for any reason, assign a Partner's designated representative to an unoccupied Partner seat by unanimous vote of all sitting Board members. In making such an initial assignment, the Board shall designate which seat (P1, P2, or P3) the representative occupies, and thereby that representative's position in the staggered rotation. Once all three Partner seats are occupied, assignments shall be made only through the annual cycle in paragraphs A through D.
 
 ### **4.6 Vacancies**
 
 Should a Board seat become vacant between Annual Meetings due to resignation, removal, loss of eligibility, or any other cause:
 
-**A.** the Chair shall notify all Members and Developers of the vacancy within fourteen (14) days;
+**A.** the Chair shall notify all Partners and Developers of the vacancy within fourteen (14) days;
 
-**B.** if the vacant seat is a Member-elected seat, the candidate from the most recent Member Board election with the next-highest approval count who is willing and eligible to serve shall be offered the seat; if no such candidate is available, the seat shall remain unfilled until the next Annual Meeting;
+**B.** if the vacant seat is a Partner seat, it shall remain unfilled until that seat next comes up for assignment under Section 4.5; the Partner institution whose representative held the seat does not thereby forfeit its standing for future assignment;
 
 **C.** if the vacant seat is a Developer-elected seat, the candidate from the most recent Developer Board election with the next-highest approval count who is willing and eligible to serve shall be offered the seat; if no such candidate is available, the seat shall remain unfilled until the next Annual Meeting;
 
@@ -243,7 +246,7 @@ A Board member subject to proposed removal shall receive notice of the grounds f
 
 The Developers consist of a self-governing body of scientists and engineers that conduct the actual work of the Consortium and execute the Consortium’s Mission. Further, the Developers help guide the strategic direction of the Consortium by holding seats on the Board.
 
-Developers may be personnel paid to work for the Consortium or unpaid community members who provide in-kind support. Developers therefore need not be in any contractual relationship with the Consortium (though they may be, for example as employees or fellows). Developers participate in the Consortium in their individual capacity. A Developer who also serves as a designated representative of a Member under Section 2.2 acts in each role separately.
+Developers may be personnel paid to work for the Consortium or unpaid community members who provide in-kind support. Developers therefore need not be in any contractual relationship with the Consortium (though they may be, for example as employees or fellows). Developers participate in the Consortium in their individual capacity. A Developer who also serves as a designated representative of a Partner under Section 2.2 acts in each role separately.
 
 Developers are expected to be active participants in the business and technical life of the Consortium by writing and reviewing code, producing technical materials, providing input and feedback to the Board, and supporting one another and the broader structural biology community.
 
@@ -318,9 +321,9 @@ Under the direction of the Board, the Director may:
 
 **C.** recommend hiring, contracting, project initiation, and budget adjustments to the Board;
 
-**D.** support Members in understanding, using, deploying, and maintaining Consortium code and related outputs, consistent with Board-approved policies and the Strategic Goals;
+**D.** support Partners in understanding, using, deploying, and maintaining Consortium code and related outputs, consistent with Board-approved policies and the Strategic Goals;
 
-**E.** recommend that requests, support needs, or feature proposals originating from Members, Developers, or other participants be elevated to the Board for consideration as Consortium-Funded Projects or budget items;
+**E.** recommend that requests, support needs, or feature proposals originating from Partners, Developers, or other participants be elevated to the Board for consideration as Consortium-Funded Projects or budget items;
 
 **F.** maintain records required under this Charter;
 
@@ -350,15 +353,15 @@ If the Director seat is unfilled, the Chair of the Board shall assume the duties
 
 ## **ARTICLE 7\. Annual Meeting**
 
-No less than once per calendar year, the Board shall convene an Annual Meeting of the Consortium, open to the representatives of all Members and to all Developers.
+No less than once per calendar year, the Board shall convene an Annual Meeting of the Consortium, open to the representatives of all Partners and to all Developers.
 
-The Annual Meeting shall serve as the primary forum for the Director and the Board to present the Strategic Goals and budget for the coming year, report on progress against prior goals, review the list of Developers, and receive recommendations from Members and Developers.
+The Annual Meeting shall serve as the primary forum for the Director and the Board to present the Strategic Goals and budget for the coming year, report on progress against prior goals, review the list of Developers, and receive recommendations from Partners and Developers.
 
-Board elections for both the Member-elected seats and the Developer-elected seats shall be conducted in conjunction with the Annual Meeting such that newly elected Board members are seated no later than the close of the Annual Meeting.
+The Partner seat then coming up shall be filled as provided in Section 4.5, and the election of the Developer-elected seats shall be conducted in conjunction with the Annual Meeting, such that newly seated Board members are seated no later than the close of the Annual Meeting.
 
-The Board shall provide no less than sixty (60) days’ notice of the Annual Meeting to all Members and Developers, including a proposed agenda.
+The Board shall provide no less than sixty (60) days’ notice of the Annual Meeting to all Partners and Developers, including a proposed agenda.
 
-Additional attendees, such as non-voting representatives of Member institutions, scientific advisors, or other guests, may be invited by the Board to attend when doing so furthers the Consortium's business.
+Additional attendees, such as non-voting representatives of Partner institutions, scientific advisors, or other guests, may be invited by the Board to attend when doing so furthers the Consortium's business.
 
 The Annual Meeting must be held in a virtual or hybrid (in-person and virtual) format, providing the possibility to participate for Consortium participants around the world.
 
@@ -372,9 +375,9 @@ For purposes of this Charter:
 
 **B. Consortium-Funded Project** means an organized effort, initiative, or workstream approved by the Board for material support by the Consortium, whether through funding, personnel, or other administered resources.
 
-**C. External Work** means work contributed independently outside Consortium support, including work created by Developers, contributors, collaborators, Members, or other participants acting outside such support.
+**C. External Work** means work contributed independently outside Consortium support, including work created by Developers, contributors, collaborators, Partners, or other participants acting outside such support.
 
-**D. Release** means making Consortium-Funded Work generally available to the public without access restriction, whether through publication of a source code repository, distribution of packaged or compiled artifacts, or equivalent means. Pre-release access provided to Members under Board-approved policy does not constitute Release.
+**D. Release** means making Consortium-Funded Work generally available to the public without access restriction, whether through publication of a source code repository, distribution of packaged or compiled artifacts, or equivalent means. Pre-release access provided to Partners under Board-approved policy does not constitute Release.
 
 Except as otherwise provided in this Charter or in agreed project-specific terms, the Consortium does not claim governance authority over purely External Work contributed outside Consortium support.
 
@@ -398,7 +401,7 @@ While public release of completed projects is the ultimate aim of the Consortium
 
 **A.** protect the ability of Consortium researchers to publish their findings without being scooped;  
 **B.** ensure that publicly released code meets a minimum standard of quality and documentation;  
-**C.** permit Members to receive pre-release access as allowed by Board-approved policy; and
+**C.** permit Partners to receive pre-release access as allowed by Board-approved policy; and
 **D.** should it be necessary, protect the security and privacy of Developers, other Consortium participants, or the broader public.
 
 Further, not all Consortium-Funded work need be publicaly released. Prototypes, internal tests, and experiments may not benefit the Mission through public release.
@@ -420,7 +423,7 @@ The right of any Consortium participant to own, publish, or otherwise pursue the
 
 The rights and obligations of contractual employees and contractors shall be stipulated in their respective contracts and by applicable law and policy.
 
-No Member, Partner, or other funder shall have authority, by virtue of funding alone, to determine scientific conclusions, compel specific scientific findings, or require authors or Developers to misstate technical or scientific results.
+No Partner or other funder shall have authority, by virtue of funding alone, to determine scientific conclusions, compel specific scientific findings, or require authors or Developers to misstate technical or scientific results.
 
 ## **ARTICLE 9\. Conflicts of Interest**
 
@@ -432,7 +435,7 @@ This policy establishes standards to identify, disclose, and manage conflicts of
 
 ### **9.2 Scope**
 
-This policy applies to all Board members, the Director, and any Developer or Member representative participating in a decision or vote on behalf of the Consortium.
+This policy applies to all Board members, the Director, and any Developer or Partner representative participating in a decision or vote on behalf of the Consortium.
 
 ### **9.3 Definition**
 
@@ -518,14 +521,14 @@ Dissolution of the Consortium may be initiated in one of the following ways:
 **B.** a unanimous vote of the full Board in favor of dissolution;  
 **C.** separation from the Operating Legal Entity with failure to transfer to a new Operating Legal Entity as provided above.
 
-Upon a valid dissolution trigger, the Board shall notify all Members, Developers, and any other parties with contractual relationships with the Consortium within ten (10) calendar days.
+Upon a valid dissolution trigger, the Board shall notify all Partners, Developers, and any other parties with contractual relationships with the Consortium within ten (10) calendar days.
 
 The Consortium shall continue operations in a wind-down capacity for no more than ninety (90) calendar days, during which:
 
 **A.** no new multi-year financial commitments shall be made;  
 **B.** the Director shall work to fulfill or responsibly terminate outstanding obligations;  
-**C.** Members shall not be entitled to refunds of amounts already paid except as required by law or contract;  
-**D.** new memberships shall not be accepted.
+**C.** Partners shall not be entitled to refunds of amounts already paid except as required by law or contract;  
+**D.** new partnerships shall not be accepted.
 
 After the wind-down period, remaining assets shall be disposed of as follows:
 
@@ -549,13 +552,15 @@ Any amendment of this Charter shall require:
 
 Upon adoption of any amendment to this Charter, the Director shall archive the prior version of the Charter and record the date of amendment, the nature of the changes made, and the vote by which the amendment was approved.
 
-All prior versions of the Charter shall be made available to any Member or Developer upon request. A version history shall be maintained as a Consortium record.
+All prior versions of the Charter shall be made available to any Partner or Developer upon request. A version history shall be maintained as a Consortium record.
 
 ## **ADOPTION OF CHARTER**
 
 The Charter shall be adopted by a set of Developers.
 
 Immediately upon adoption, the initial Developers shall convene a special meeting to elect the first Developer-elected representatives to the Board. At this special election, the Developers shall elect up to three (3) Board members; by a two-thirds (2/3) vote, the Developers may instead elect fewer than three. The election shall otherwise follow the procedure set out in Section 5.5, applied to the number of seats to be filled. Any Developer-elected seats not filled at the special election shall remain vacant until the first Annual Meeting.
+
+To establish the staggered rotation of the Partner seats required by Section 4.2, the terms of Seats P1, P2, and P3 shall expire, respectively, at the first, second, and third Annual Meeting following adoption, and every three (3) years thereafter, so that the term of one Partner seat comes up for assignment each year. The Partner seats begin unoccupied and may be filled before the seat's first scheduled expiry through the initial-assignment procedure in Section 4.5.E; a representative initially assigned to a seat serves until that seat's next scheduled expiry. Thereafter, each Partner seat is filled for a full three-year term as provided in Sections 4.2 and 4.5.
 
 The Board shall set the date of the first Annual Meeting, at which the next election of Board members shall be held as required by this Charter. The first Annual Meeting may be held on any date set by the Board, provided it occurs no later than twelve (12) months following adoption of this Charter.
 

--- a/board-policies/README.md
+++ b/board-policies/README.md
@@ -2,6 +2,6 @@
 
 This directory holds written policies adopted by the Governing Board of the Reciprocal Space Station Consortium under Article 4.3.J of the [Charter](../RSS-charter.md).
 
-Board policies are binding and direct the work of the Consortium on matters within the Board's authority — including release and publication, contributions and intellectual property, membership and partnership terms, and funding and project approval. All policies here must be consistent with the Charter; in the event of conflict, the Charter controls.
+Board policies are binding and direct the work of the Consortium on matters within the Board's authority — including release and publication, contributions and intellectual property, partnership terms, and funding and project approval. All policies here must be consistent with the Charter; in the event of conflict, the Charter controls.
 
 Policies are adopted, amended, and repealed by majority vote of the Board (Article 4.4).

--- a/membership/README.md
+++ b/membership/README.md
@@ -1,8 +1,8 @@
-# Membership
+# Partnership
 
-This directory holds draft documents that establish the terms of membership in the Reciprocal Space Station Consortium under Article 3 of the [Charter](../RSS-charter.md).
+This directory holds draft documents that establish the terms of partnership in the Reciprocal Space Station Consortium under Article 3 of the [Charter](../RSS-charter.md).
 
-- [`schedule.md`](schedule.md) — the Membership Schedule, summarizing the Member and Partner tiers, contribution levels, and standard benefits. Tier definitions and benefits are set by Board-approved policy (Article 3.2) and may evolve over time.
-- [`agreement-template.md`](agreement-template.md) — the template Membership Agreement entered into between each Member institution and the Operating Legal Entity on behalf of the Consortium.
+- [`schedule.md`](schedule.md) — the Partnership Schedule, summarizing the partnership contribution level and standard benefits. Contribution levels and benefits are set by Board-approved policy (Article 3.2) and may evolve over time.
+- [`agreement-template.md`](agreement-template.md) — the template Partnership Agreement entered into between each Partner institution and the Operating Legal Entity on behalf of the Consortium.
 
-Membership is governed by the Charter, Board-approved policies, and the executed Agreement; in the event of conflict, the hierarchy in Article 10.2 controls.
+Partnership is governed by the Charter, Board-approved policies, and the executed Agreement; in the event of conflict, the hierarchy in Article 10.2 controls.

--- a/membership/agreement-template.md
+++ b/membership/agreement-template.md
@@ -1,16 +1,16 @@
-# **MEMBERSHIP AGREEMENT**
+# **PARTNERSHIP AGREEMENT**
 
 ## **Reciprocal Space Station Consortium**
 
-This Membership Agreement (the “**Agreement**”) is entered into as of **\[Effective Date\]** (the “**Effective Date**”) by and between:
+This Partnership Agreement (the “**Agreement**”) is entered into as of **\[Effective Date\]** (the “**Effective Date**”) by and between:
 
 **Open Molecular Software Foundation**, a **\[jurisdiction and entity type\]** (“**OMSF**”), acting as the Operating Legal Entity for the Reciprocal Space Station Consortium (“**RSS**” or the “**Consortium**”),
 
 and
 
-**\[Member Legal Name\]**, a **\[jurisdiction and entity type\]** (“**Member**”).
+**\[Partner Legal Name\]**, a **\[jurisdiction and entity type\]** (“**Partner**”).
 
-OMSF and Member may each be referred to herein as a “**Party**” and together as the “**Parties**.”
+OMSF and Partner may each be referred to herein as a “**Party**” and together as the “**Parties**.”
 
 ---
 
@@ -18,7 +18,7 @@ OMSF and Member may each be referred to herein as a “**Party**” and together
 
 RSS is an academic consortium supporting the development of open-source software for structural biology, together with related activities that advance the development, adoption, sustainability, and scientific value of such software.
 
-The purpose of this Agreement is to set forth the terms under which Member joins RSS as a **\[Member / Partner\]** tier participant and receives the rights and benefits associated with that tier, subject to the Charter of RSS, applicable RSS policies, and the terms of this Agreement.
+The purpose of this Agreement is to set forth the terms under which Partner joins RSS as a Partner and receives the associated rights and benefits, subject to the Charter of RSS, applicable RSS policies, and the terms of this Agreement.
 
 ---
 
@@ -26,21 +26,19 @@ The purpose of this Agreement is to set forth the terms under which Member joins
 
 This Agreement is entered into in connection with the Charter of the Reciprocal Space Station Consortium (the “**Charter**”).
 
-Member acknowledges that RSS is governed by the Charter and by Board-approved policies applicable to Members, including policies governing release, publication, pre-release access, and use of Consortium resources.
+Partner acknowledges that RSS is governed by the Charter and by Board-approved policies applicable to Partners, including policies governing release, publication, pre-release access, and use of Consortium resources.
 
-In the event of conflict between this Agreement and the Charter, the Charter shall govern with respect to Consortium governance, voting rights, Board structure, Developer authority, and scientific or technical decision-making. This Agreement shall govern with respect to the contractual rights and obligations between OMSF and Member, except to the extent otherwise required by applicable law or the governing documents or binding policies of OMSF.
+In the event of conflict between this Agreement and the Charter, the Charter shall govern with respect to Consortium governance, voting rights, Board structure, Developer authority, and scientific or technical decision-making. This Agreement shall govern with respect to the contractual rights and obligations between OMSF and Partner, except to the extent otherwise required by applicable law or the governing documents or binding policies of OMSF.
 
 ---
 
-## **3\. Membership Tier**
+## **3\. Partnership**
 
-Member is admitted to RSS in the following tier:
+Partner is admitted to RSS as a Partner of the Consortium.
 
-**Membership Tier:** **\[Member / Partner\]**
+The rights and benefits of partnership are described in this Agreement and in **Exhibit A**.
 
-The rights and benefits associated with that tier are described in this Agreement and in **Exhibit A**.
-
-If Member’s tier changes during the Term by written agreement of the Parties, the revised tier and associated benefits shall take effect on the date stated in that written agreement.
+The contribution level, benefits, and other conditions of partnership may be set by Board-approved policy and may evolve over time, as provided in the Charter.
 
 ---
 
@@ -52,40 +50,40 @@ After the Initial Term, this Agreement shall automatically renew for successive 
 
 ---
 
-## **5\. Membership Fee and Payment**
+## **5\. Partnership Fee and Payment**
 
-Member shall pay OMSF a membership fee in the amount of **\[amount\]** for the Initial Term.
+Partner shall pay OMSF a partnership fee in the amount of **\[amount\]** for the Initial Term.
 
-Unless otherwise stated in an applicable invoice or written amendment, membership fees shall be due within thirty (30) days of invoice.
+Unless otherwise stated in an applicable invoice or written amendment, partnership fees shall be due within thirty (30) days of invoice.
 
 All amounts are payable in **\[currency\]** and are non-refundable except as expressly provided in this Agreement or required by law.
 
 Late payments may result in suspension of benefits or loss of Good Standing under the Charter after any applicable notice and cure period.
 
-If OMSF or RSS adopts a revised membership fee schedule for Renewal Terms, OMSF shall provide Member reasonable advance notice before such revised fees take effect.
+If OMSF or RSS adopts a revised partnership fee schedule for Renewal Terms, OMSF shall provide Partner reasonable advance notice before such revised fees take effect.
 
 ---
 
 ## **6\. Designated Representative**
 
-Member shall designate one individual to act as its primary representative for purposes of participation in RSS (the “**Designated Representative**”).
+Partner shall designate one individual to act as its primary representative for purposes of participation in RSS (the “**Designated Representative**”).
 
 The Designated Representative may:
 
 * receive notices under this Agreement;  
-* participate in RSS meetings and communications intended for Members;  
-* cast Member votes as permitted under the Charter; and  
-* coordinate Member access to benefits under this Agreement.
+* participate in RSS meetings and communications intended for Partners;  
+* act for the Partner in Consortium matters as permitted under the Charter; and  
+* coordinate Partner access to benefits under this Agreement.
 
-Member may change its Designated Representative by written notice to OMSF.
+Partner may change its Designated Representative by written notice to OMSF.
 
-If Member is a Partner, its Designated Representative shall be eligible to stand for election to a Member-elected Board seat, subject to the Charter.
+The Designated Representative is eligible to be seated on the Board on the Partner's behalf according to the Partner's contributions to the Consortium, as provided in the Charter.
 
 ---
 
-## **7\. Membership Benefits**
+## **7\. Partnership Benefits**
 
-During the Term, and subject to Member remaining in Good Standing, Member shall be eligible to receive the benefits associated with its tier as set forth in **Exhibit A**.
+During the Term, and subject to Partner remaining in Good Standing, Partner shall be eligible to receive the benefits associated with its tier as set forth in **Exhibit A**.
 
 Such benefits may include:
 
@@ -103,7 +101,7 @@ Support benefits are intended to provide priority access to RSS personnel and ch
 
 ## **8\. Limits on Benefits**
 
-Member acknowledges and agrees that membership in RSS does not confer:
+Partner acknowledges and agrees that partnership in RSS does not confer:
 
 **A.** ownership of Consortium intellectual property;
 
@@ -115,15 +113,15 @@ Member acknowledges and agrees that membership in RSS does not confer:
 
 **E.** any exclusive right to Consortium personnel time, feature implementation, or project prioritization unless expressly stated in a separate written agreement or statement of work signed by OMSF.
 
-Member further acknowledges that RSS is an open-source scientific software consortium and not, by default, a custom software development contractor for any particular Member.
+Partner further acknowledges that RSS is an open-source scientific software consortium and not, by default, a custom software development contractor for any particular Partner.
 
 ---
 
 ## **9\. Pre-Release Materials; Confidentiality**
 
-From time to time, Members may receive access to pre-release software, internal builds, draft documentation, or other non-public Consortium materials (“**Pre-Release Materials**”) as a membership benefit.
+From time to time, Partners may receive access to pre-release software, internal builds, draft documentation, or other non-public Consortium materials (“**Pre-Release Materials**”) as a partnership benefit.
 
-Pre-Release Materials shall be treated as confidential and used solely for Member’s internal evaluation, testing, and feedback. Members shall not disclose Pre-Release Materials to third parties, except to employees or contractors bound by comparable confidentiality obligations, or redistribute them publicly.
+Pre-Release Materials shall be treated as confidential and used solely for Partner’s internal evaluation, testing, and feedback. Partners shall not disclose Pre-Release Materials to third parties, except to employees or contractors bound by comparable confidentiality obligations, or redistribute them publicly.
 
 Access to Pre-Release Materials does not confer ownership of Consortium intellectual property or control over the timing or content of public releases.
 
@@ -135,9 +133,9 @@ The confidentiality obligations in this Section shall survive termination of thi
 
 ## **10\. Feedback**
 
-Member may provide feedback, suggestions, feature requests, bug reports, comments, or other input relating to RSS software or activities (“**Feedback**”).
+Partner may provide feedback, suggestions, feature requests, bug reports, comments, or other input relating to RSS software or activities (“**Feedback**”).
 
-Unless the Parties agree otherwise in writing, Member grants OMSF, on behalf of RSS, a nonexclusive, worldwide, perpetual, irrevocable, royalty-free right to use, reproduce, modify, and incorporate such Feedback without restriction or compensation to Member.
+Unless the Parties agree otherwise in writing, Partner grants OMSF, on behalf of RSS, a nonexclusive, worldwide, perpetual, irrevocable, royalty-free right to use, reproduce, modify, and incorporate such Feedback without restriction or compensation to Partner.
 
 For clarity, Feedback does not by itself obligate RSS to implement any suggestion or undertake any project.
 
@@ -145,14 +143,14 @@ For clarity, Feedback does not by itself obligate RSS to implement any suggestio
 
 ## **11\. Names, Marks, and Publicity**
 
-Subject to Member’s prior written notice opting out, OMSF or RSS may identify Member by name and logo as a Member or Partner of RSS in publicly available supporter lists, websites, annual reports, slide decks, and similar materials.
+Subject to Partner’s prior written notice opting out, OMSF or RSS may identify Partner by name and logo as a Partner of RSS in publicly available supporter lists, websites, annual reports, slide decks, and similar materials.
 
-Member may state publicly that it is a Member or Partner of RSS, provided that such statement is accurate and does not imply:
+Partner may state publicly that it is a Partner of RSS, provided that such statement is accurate and does not imply:
 
-* that Member controls RSS;  
-* that RSS endorses Member’s products or services;  
-* that Member owns RSS intellectual property; or  
-* that Member speaks on behalf of OMSF, RSS, or other Consortium participants.
+* that Partner controls RSS;  
+* that RSS endorses Partner’s products or services;  
+* that Partner owns RSS intellectual property; or  
+* that Partner speaks on behalf of OMSF, RSS, or other Consortium participants.
 
 Except as expressly provided in this Section, neither Party may use the other Party’s name, trademarks, or logos without prior written permission.
 
@@ -160,21 +158,21 @@ Except as expressly provided in this Section, neither Party may use the other Pa
 
 ## **12\. Intellectual Property and Open-Source Principles**
 
-Member acknowledges that RSS is an open-source consortium and that Consortium software is intended to be publicly released under permissive open-source terms in accordance with the Charter and applicable RSS policy.
+Partner acknowledges that RSS is an open-source consortium and that Consortium software is intended to be publicly released under permissive open-source terms in accordance with the Charter and applicable RSS policy.
 
 Except as expressly set forth in a separate written agreement, this Agreement does not transfer ownership of any intellectual property between the Parties.
 
-Member retains ownership of its own pre-existing intellectual property.
+Partner retains ownership of its own pre-existing intellectual property.
 
 OMSF and RSS retain whatever rights they have in Consortium intellectual property, subject to the Charter, applicable contributor arrangements, employment agreements, contractor agreements, and applicable law.
 
-Nothing in this Agreement grants Member any exclusive license or exclusive access to Consortium intellectual property.
+Nothing in this Agreement grants Partner any exclusive license or exclusive access to Consortium intellectual property.
 
 ---
 
-## **13\. Additional Work Beyond Standard Membership**
+## **13\. Additional Work Beyond Standard Partnership**
 
-If Member requests work that exceeds ordinary membership support or falls outside current RSS priorities, RSS may, in its discretion, consider whether such work should be:
+If Partner requests work that exceeds ordinary partnership support or falls outside current RSS priorities, RSS may, in its discretion, consider whether such work should be:
 
 * elevated into a specific Consortium-Funded Project through RSS governance processes; or  
 * addressed through a separate written agreement or statement of work signed by OMSF.
@@ -189,7 +187,7 @@ Each Party enters into this Agreement only on its own behalf.
 
 No individual participating in RSS by virtue of this Agreement is, solely by reason of such participation, authorized to bind any other institution, laboratory, university, government entity, or affiliate unless separately authorized in writing.
 
-If Member is entering this Agreement on behalf of a university, company, laboratory, or other institution, Member represents that the signatory to this Agreement is authorized to bind that entity.
+If Partner is entering this Agreement on behalf of a university, company, laboratory, or other institution, Partner represents that the signatory to this Agreement is authorized to bind that entity.
 
 ---
 
@@ -197,7 +195,7 @@ If Member is entering this Agreement on behalf of a university, company, laborat
 
 RSS software, Pre-Release Materials, documentation, and related outputs are provided “as is” and “as available,” without warranties of any kind, whether express, implied, statutory, or otherwise, including implied warranties of merchantability, fitness for a particular purpose, non-infringement, accuracy, or uninterrupted availability.
 
-Member acknowledges that pre-release and research-stage software may be incomplete, unstable, or unsuitable for production use.
+Partner acknowledges that pre-release and research-stage software may be incomplete, unstable, or unsuitable for production use.
 
 OMSF does not warrant that any particular feature, roadmap item, or research direction will be implemented, completed, or publicly released on any specific schedule, except as may be expressly set forth in a separate written agreement.
 
@@ -207,7 +205,7 @@ OMSF does not warrant that any particular feature, roadmap item, or research dir
 
 To the fullest extent permitted by law, neither Party shall be liable to the other for any indirect, incidental, special, consequential, exemplary, or punitive damages, or for any loss of profits, revenues, data, or business opportunity, arising out of or relating to this Agreement, even if advised of the possibility of such damages.
 
-To the fullest extent permitted by law, each Party’s aggregate liability arising out of or relating to this Agreement shall not exceed the amount of membership fees actually paid by Member under this Agreement during the twelve (12) months preceding the event giving rise to the claim.
+To the fullest extent permitted by law, each Party’s aggregate liability arising out of or relating to this Agreement shall not exceed the amount of partnership fees actually paid by Partner under this Agreement during the twelve (12) months preceding the event giving rise to the claim.
 
 ---
 
@@ -217,11 +215,11 @@ Either Party may terminate this Agreement for convenience upon sixty (60) days�
 
 Either Party may terminate this Agreement for material breach if the other Party fails to cure such breach within thirty (30) days after receiving written notice describing the breach in reasonable detail.
 
-OMSF may suspend Member benefits or terminate this Agreement immediately if:
+OMSF may suspend Partner benefits or terminate this Agreement immediately if:
 
-* Member ceases to be eligible for participation under applicable law;  
-* Member materially violates confidentiality obligations relating to Pre-Release Materials;  
-* Member materially misuses RSS name, marks, or non-public materials; or  
+* Partner ceases to be eligible for participation under applicable law;  
+* Partner materially violates confidentiality obligations relating to Pre-Release Materials;  
+* Partner materially misuses RSS name, marks, or non-public materials; or  
 * continued participation would place OMSF or RSS in legal or policy conflict.
 
 Termination of this Agreement shall ordinarily result in loss of Good Standing unless otherwise determined under the Charter.
@@ -232,11 +230,11 @@ Termination of this Agreement shall ordinarily result in loss of Good Standing u
 
 Upon expiration or termination of this Agreement:
 
-**A.** Member’s rights to receive membership benefits shall cease, except as expressly stated otherwise herein;
+**A.** Partner’s rights to receive partnership benefits shall cease, except as expressly stated otherwise herein;
 
-**B.** Member shall cease representing itself as a current Member or Partner of RSS;
+**B.** Partner shall cease representing itself as a current Partner of RSS;
 
-**C.** Member shall discontinue use of any non-public Pre-Release Materials, except to the extent continued retention is reasonably necessary for legal compliance, archival purposes, or internal recordkeeping, subject to continuing confidentiality obligations; and
+**C.** Partner shall discontinue use of any non-public Pre-Release Materials, except to the extent continued retention is reasonably necessary for legal compliance, archival purposes, or internal recordkeeping, subject to continuing confidentiality obligations; and
 
 **D.** accrued payment obligations and any provisions that by their nature should survive shall remain in effect.
 
@@ -264,7 +262,7 @@ This Agreement, together with any exhibits, the Charter as incorporated or attac
 
 ### **19.5 Amendment**
 
-This Agreement may be amended only in a writing signed by both Parties, except that Board-approved generally applicable policies or schedules referenced in this Agreement may be updated in accordance with their own terms, provided such updates do not retroactively deprive Member of material benefits already paid for during the current Term unless required by law or OMSF policy.
+This Agreement may be amended only in a writing signed by both Parties, except that Board-approved generally applicable policies or schedules referenced in this Agreement may be updated in accordance with their own terms, provided such updates do not retroactively deprive Partner of material benefits already paid for during the current Term unless required by law or OMSF policy.
 
 ### **19.6 Severability**
 
@@ -288,7 +286,7 @@ Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_  
 Date: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 
-**\[MEMBER LEGAL NAME\]**  
+**\[PARTNER LEGAL NAME\]**  
 By: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_  
 Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_  
 Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_  
@@ -298,22 +296,20 @@ Date: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 
 # **EXHIBIT A**
 
-## **Tier-Specific Benefits**
+## **Partner Benefits**
 
-The benefits below apply during the Term, subject to Member remaining in Good Standing, the Charter, and applicable RSS policies.
+The benefits below apply during the Term, subject to Partner remaining in Good Standing, the Charter, and applicable RSS policies.
 
-### **1\. Member Tier**
-
-A Member in Good Standing is entitled to:
+A Partner in Good Standing is entitled to:
 
 **A. Designated Representative.**  
-Designation of one representative to participate in RSS business on the Member’s behalf.
+Designation of one representative to participate in RSS business on the Partner’s behalf.
 
 **B. Annual Meeting Participation.**  
-Attendance at the RSS Annual Meeting and other Member-facing RSS communications and discussions.
+Attendance at the RSS Annual Meeting and other Partner-facing RSS communications and discussions.
 
-**C. Voting Rights.**  
-One ballot in elections for Member-elected Board seats, cast through the Member’s Designated Representative, as provided in the Charter.
+**C. Board Representation.**  
+Eligibility for the Partner’s Designated Representative to be seated on the Board on the Partner’s behalf according to the Partner’s contributions to the Consortium, as provided in the Charter.
 
 **D. Strategic Input.**  
 The opportunity to recommend strategic directions, projects, features, educational materials, and other priorities to the Board and Director.
@@ -321,31 +317,21 @@ The opportunity to recommend strategic directions, projects, features, education
 **E. Priority Support Access.**  
 Priority access to RSS communication channels for questions, feedback, deployment guidance, maintenance discussions, and related support concerning Consortium software and outputs, subject to available project capacity and Board-approved policies.
 
-**F. Confidential Member Communications.**  
-Access to confidential or limited-access communications made available to Members regarding pre-release development, roadmap discussion, or support matters, as determined by RSS policy.
+**F. Confidential Partner Communications.**  
+Access to confidential or limited-access communications made available to Partners regarding pre-release development, roadmap discussion, or support matters, as determined by RSS policy.
 
 **G. Pre-Release Access.**  
 Eligibility for access to certain non-public pre-release software, unstable internal builds, draft documentation, or related technical materials for internal evaluation, testing, and feedback, where provided by RSS policy.
 
 **H. Public Recognition.**  
-Recognition as a Member of RSS in supporter lists, websites, presentations, or similar materials, unless the Member requests otherwise.
+Recognition as a Partner of RSS in supporter lists, websites, presentations, or similar materials, unless the Partner requests otherwise.
 
-### **2\. Partner Tier**
+**I. Additional Engagement and Program Access.**  
+Eligibility for any additional engagement opportunities, meetings, communication channels, pre-release access, technical discussions, or programmatic benefits that RSS may make available from time to time under Board-approved policy, provided always that such benefits do not confer ownership of RSS intellectual property or control over scientific conclusions.
 
-A Partner in Good Standing receives all Member-tier benefits, and in addition:
+### **General Limits**
 
-**A. Board Eligibility.**  
-The Partner’s Designated Representative is eligible to stand for election to a Member-elected Board seat, as provided in the Charter.
-
-**B. Enhanced Engagement.**  
-Eligibility for any additional Partner-level engagement opportunities, meetings, or communication channels that RSS may make available from time to time under Board-approved policy.
-
-**C. Enhanced Pre-Release / Program Access.**  
-Eligibility for any additional Partner-level pre-release access, technical discussions, or programmatic benefits that RSS may make available under Board-approved policy, provided always that such benefits do not confer ownership of RSS intellectual property or control over scientific conclusions.
-
-### **3\. General Limits Applicable to All Tiers**
-
-For clarity, membership benefits do not include:
+For clarity, partnership benefits do not include:
 
 * ownership of Consortium intellectual property;  
 * unilateral control over scientific conclusions;  
@@ -353,5 +339,5 @@ For clarity, membership benefits do not include:
 * guaranteed engineering hours, guaranteed feature delivery, or guaranteed response times unless expressly provided in a separate written agreement; or  
 * exclusive access to RSS personnel or exclusive rights to custom development.
 
-If a Member requests work that exceeds ordinary support or falls outside current priorities, RSS may, in its discretion, consider whether such work should be elevated into a specific Consortium-Funded Project or addressed through a separate written arrangement.
+If a Partner requests work that exceeds ordinary support or falls outside current priorities, RSS may, in its discretion, consider whether such work should be elevated into a specific Consortium-Funded Project or addressed through a separate written arrangement.
 

--- a/membership/schedule.md
+++ b/membership/schedule.md
@@ -1,27 +1,26 @@
 # **Reciprocal Space Station Consortium**
 
-## **Membership Overview**
+## **Partnership Overview**
 
 **Effective Date:** \[Date\]  
 **Administered By:** Open Molecular Software Foundation, as Operating Legal Entity for RSS
 
-The Reciprocal Space Station Consortium (“RSS”) is an academic consortium supporting the development of open-source software for structural biology. Membership supports the development, maintenance, dissemination, and long-term sustainability of RSS software and related community activities.
+The Reciprocal Space Station Consortium (“RSS”) is an academic consortium supporting the development of open-source software for structural biology. Partnership supports the development, maintenance, dissemination, and long-term sustainability of RSS software and related community activities.
 
-## **Membership Tiers**
-
-**Member**  
- Annual Contribution: **\[amount\]**
+## **Partnership**
 
 **Partner**  
  Annual Contribution: **\[amount\]**
 
-## **All Members Receive**
+Contribution levels and benefits are set by Board-approved policy (Article 3.2) and may evolve over time.
+
+## **All Partners Receive**
 
 * One designated representative
 
-* Participation in the RSS Annual Meeting and member communications
+* Participation in the RSS Annual Meeting and partner communications
 
-* One vote in elections for Member-elected Board seats
+* Consideration for a Partner seat on the Board according to the Partner's contributions to the Consortium, as provided in the Charter
 
 * The opportunity to recommend strategic directions, projects, features, and priorities
 
@@ -31,19 +30,9 @@ The Reciprocal Space Station Consortium (“RSS”) is an academic consortium su
 
 * Public recognition as an RSS supporter, unless requested otherwise
 
-## 
+## **What Partnership Does Not Include**
 
-## **Additional Partner Benefits**
-
-* Eligibility for the designated representative to stand for election to a Member-elected Board seat
-
-* Additional Partner-level engagement opportunities with RSS
-
-* Eligibility for additional Partner-level pre-release access and programmatic benefits, as defined by RSS policy
-
-## **What Membership Does Not Include**
-
-Membership does not provide:
+Partnership does not provide:
 
 * ownership of RSS intellectual property  
 * control over scientific conclusions  
@@ -51,9 +40,9 @@ Membership does not provide:
 * exclusive access to RSS personnel  
 * exclusive rights to custom development
 
-Requests beyond ordinary membership support may be considered for a separately scoped project or other written arrangement.
+Requests beyond ordinary partnership support may be considered for a separately scoped project or other written arrangement.
 
 ## **Notes**
 
-Membership is governed by the RSS Charter, applicable membership terms, and OMSF policies.  Specific benefits may evolve over time as RSS grows.
+Partnership is governed by the RSS Charter, applicable partnership terms, and OMSF policies.  Specific benefits may evolve over time as RSS grows.
 


### PR DESCRIPTION
This PR attempts to address #23 -- devising a better way to elect Member/Partner institutions to the Board.

Changes:

- Collapsed the two-tier "Member/Partner" model into a single Partner tier (renamed throughout the Charter and membership/ docs), and 
- replaced the elected Partner board seats with contribution-based assignment:
  - 3 Partner seats (P1/P2/P3), staggered 3-year terms, one coming up each year.
  - The seat goes to the largest contributor (cash + in-kind, with in-kind discounted 20%), measured over the prior two years realized + next year promised. Time-frame anchored to the last board meeting before the Annual Meeting.
  - Assignment requires board ratification; a unanimous board vote rejects it and passes eligibility to the next contributor.
  - Before all seats are filled, the board may initially assign seats at any time by unanimous vote, choosing which to fill (P1/P2/P3).

Aligned terminology with PR [#24](https://github.com/rs-station/charter/issues/24)'s rotating Developer seats. 

- [ ] Governance diagram still needs updating.